### PR TITLE
Detectar productos con envío gratis por precio

### DIFF
--- a/dbfreeshipping.php
+++ b/dbfreeshipping.php
@@ -252,9 +252,19 @@ class Dbfreeshipping extends Module
         $remains_calc = round((float)$free - (float)$total_cart, 2);
         $remains = $this->context->currentLocale->formatNumber($remains_calc).$this->context->currency->symbol;
         $porcent = round((float)$total_cart * 100 / (float)$free, 0);
+
         if ((float)$total_cart > (float)$free) {
             $is_free = true;
             $porcent = 100;
+        }
+
+        $id_product = Tools::getValue('id_product');
+
+        if ($id_product) {
+            $price = Product::getPriceStatic($id_product);
+            if ((float)$price >= (float)$free) {
+                $product_free_shipping = true;
+            }
         }
 
         return array(
@@ -262,19 +272,23 @@ class Dbfreeshipping extends Module
             'porcent' => $porcent,
             'remains' => $remains,
             'free' => $free_show,
+            'product_free_shipping' => $product_free_shipping
         );
     }
 
     public function hookdisplayProductAdditionalInfo()
     {
-
         $shipping = $this->getFreeShippingTotal();
+
         $this->context->smarty->assign(array(
             'free' => $shipping['free'],
             'is_free' => $shipping['is_free'],
             'remains' => $shipping['remains'],
             'porcent' => $shipping['porcent'],
-        ));
+            'product_free_shipping' => $shipping['product_free_shipping'],
+            )
+        );
+
         return $this->display(__FILE__, 'views/templates/hook/product.tpl');
     }
 

--- a/views/templates/hook/product.tpl
+++ b/views/templates/hook/product.tpl
@@ -1,9 +1,15 @@
 {if $is_free}
     <p class="dbfreeshipping">{l s='Ya tienes el' mod='dbfreeshipping'} <strong>{l s='envío gratuito' mod='dbfreeshipping'}</strong></p>
 {else}
-    <p class="dbfreeshipping">
-        {l s='Te quedan' mod='dbfreeshipping'}
-        <strong>{$remains}</strong>
-        {l s='para el envío gratis' mod='dbfreeshipping'}
-    </p>
+    {if $product_free_shipping}
+        <p class="dbfreeshipping">
+            {l s='Recibe este producto sin gastos de envío' mod='dbfreeshipping'}
+        </p>
+    {else}
+        <p class="dbfreeshipping">
+            {l s='Te quedan' mod='dbfreeshipping'}
+            <strong>{$remains}</strong>
+            {l s='para el envío gratis' mod='dbfreeshipping'}
+        </p>
+    {/if}
 {/if}


### PR DESCRIPTION
Detectar los productos cuyo precio es superior al límite para gastos de
envío gratuitos y mostrar el mensaje correspondiente.

<img width="781" alt="Captura de pantalla 2021-09-16 a las 15 53 44" src="https://user-images.githubusercontent.com/1695138/133624787-72f8047b-b126-4c02-a55f-5e7ab32376b6.png">